### PR TITLE
fix: compile with qt6 and grass

### DIFF
--- a/src/providers/grass/qgsgrassprovider.cpp
+++ b/src/providers/grass/qgsgrassprovider.cpp
@@ -505,7 +505,7 @@ int QgsGrassProvider::grassLayer( const QString &name )
     return -1;
   }
 
-  return name.leftRef( pos ).toInt();
+  return name.left( pos ).toInt();
 }
 
 int QgsGrassProvider::grassLayerType( const QString &name )


### PR DESCRIPTION
## fix: compile with qt6 and grass

Currently the compilation with qt6 and grass fails.
Reason is Class `<QStringRef>` was removed in Qt6. https://doc-snapshots.qt.io/qt6-dev/qtcore-changes-qt6.html#the-qstringref-class
And the function `leftRef()` was entierly dropped. 

Solution is to replace `leftRef()` with `left()`. This change is backward compatible with Qt5.

Fixes https://github.com/qgis/QGIS/issues/47848